### PR TITLE
clickhouse-sqlalchemy 0.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,8 @@ test:
     - clickhouse_sqlalchemy.drivers.native
     - clickhouse_sqlalchemy.orm
     - clickhouse_sqlalchemy.sql
+  requires:
+    - pip
   commands: 
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  # clickhouse-driver isn't available on s390x and aarch64.
+  skip: True  # [py<37 or (linux and (s390x or aarch64))]
   script: pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.6" %}
+{% set version = "0.2.3" %}
 
 package:
   name: clickhouse-sqlalchemy
@@ -6,23 +6,25 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/clickhouse-sqlalchemy/clickhouse-sqlalchemy-{{ version }}.tar.gz
-  sha256: 402d112e2c7e8c7f28fd2691c5efaf701c1c19831c10a38c9355a07dd8d308a9
+  sha256: 6df4c125db428b856f8a7ec392190d9a4a2bb281eecb4fca2202e9d49ee4d55f
 
 build:
   number: 0
-  noarch: python
-  script: pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<37]
+  script: pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
+    - python
+    - setuptools
+    - wheel
 
   run:
     - python
-    - six
-    - sqlalchemy
+    - clickhouse-driver >=0.1.2
     - requests
-    - clickhouse-driver >=0.0.14
+    - sqlalchemy >=1.4,<1.5
 
 test:
   imports:
@@ -32,13 +34,21 @@ test:
     - clickhouse_sqlalchemy.drivers.native
     - clickhouse_sqlalchemy.orm
     - clickhouse_sqlalchemy.sql
+  requires: 
+    - pip
+  commands: 
+    - pip check
 
 about:
   home: https://github.com/xzkostyan/clickhouse-sqlalchemy
+  dev_url: https://github.com/xzkostyan/clickhouse-sqlalchemy
+  doc_url: https://github.com/xzkostyan/clickhouse-sqlalchemy
   license: MIT
-  summary: Simple ClickHouse SQLAlchemy Dialect
-  license_file: LICENSE
   license_family: MIT
+  license_file: LICENSE
+  summary: Simple ClickHouse SQLAlchemy Dialect
+  description: |
+    Simple ClickHouse SQLAlchemy Dialect.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   # clickhouse-driver isn't available on s390x and aarch64.
   skip: True  # [py<37 or (linux and (s390x or aarch64))]
-  script: pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -35,8 +35,6 @@ test:
     - clickhouse_sqlalchemy.drivers.native
     - clickhouse_sqlalchemy.orm
     - clickhouse_sqlalchemy.sql
-  requires: 
-    - pip
   commands: 
     - pip check
 


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| defaults | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/clickhouse-sqlalchemy.svg)](https://anaconda.org/main/clickhouse-sqlalchemy) | [![Conda Version](https://img.shields.io/conda/vn/main/clickhouse-sqlalchemy.svg)](https://anaconda.org/main/clickhouse-sqlalchemy) | [![Conda Platforms](https://img.shields.io/conda/pn/main/clickhouse-sqlalchemy.svg)](https://anaconda.org/main/clickhouse-sqlalchemy) | ![Conda License](https://img.shields.io/conda/l/main/clickhouse-sqlalchemy) |

Changelog: https://github.com/xzkostyan/clickhouse-sqlalchemy/blob/0.2.3/CHANGELOG.md
License: https://github.com/xzkostyan/clickhouse-sqlalchemy/blob/0.2.4/LICENSE
Requirements: https://github.com/xzkostyan/clickhouse-sqlalchemy/blob/0.2.3/setup.py

Actions:
1. Clean up the noarch recipe
2. Skip s390x and aarch64
3. Update `sqlalchemy` pin in run
4. Add pip check
5. Add dev & doc urls, and description

Notes:
- We update this package because of its incompatibility with **sqlalchemy 2.x.x**
