### PR TITLE
clickhouse-sqlalchemy 0.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/asynch-feedstock/pr1/5846bd9
+  - https://staging.continuum.io/prefect/fs/python-zstd-feedstock/pr1/39b6afe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/asynch-feedstock/pr1/5846bd9
-  - https://staging.continuum.io/prefect/fs/python-zstd-feedstock/pr1/39b6afe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - python
     - clickhouse-driver >=0.1.2
     - requests
-    - sqlalchemy >=1.4,<1.5
+    - sqlalchemy >=2.0.0,<2.1.0
+    - asynch >=0.2.2
 
 test:
   imports:
@@ -37,7 +38,7 @@ test:
     - clickhouse_sqlalchemy.sql
   requires:
     - pip
-  commands: 
+  commands:
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.3" %}
+{% set version = "0.3.2" %}
 
 package:
   name: clickhouse-sqlalchemy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/clickhouse-sqlalchemy/clickhouse-sqlalchemy-{{ version }}.tar.gz
-  sha256: 6df4c125db428b856f8a7ec392190d9a4a2bb281eecb4fca2202e9d49ee4d55f
+  sha256: 267f3a9a1d0d186eb99a41895a684922d31125cea21702cd7dc73af1ccdd10e7
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4681](https://anaconda.atlassian.net/browse/PKG-4681)
- [Upstream repository](https://github.com/xzkostyan/clickhouse-sqlalchemy/tree/0.3.2)
- [Upstream changelog/diff](https://github.com/xzkostyan/clickhouse-sqlalchemy/blob/0.3.2/CHANGELOG.md)

### Explanation of changes:

- Update version and sha256
- Update dependencies


[PKG-4681]: https://anaconda.atlassian.net/browse/PKG-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ